### PR TITLE
[cmake] fix Gaudi CMake namespace error

### DIFF
--- a/SimG4Common/CMakeLists.txt
+++ b/SimG4Common/CMakeLists.txt
@@ -6,7 +6,7 @@
 file(GLOB _lib_sources src/*.cpp)
 gaudi_add_library(SimG4Common
                  SOURCES ${_lib_sources}
-                 LINK GaudiAlgLib k4FWCore::k4FWCore ${Geant4_LIBRARIES} EDM4HEP::edm4hep
+                 LINK Gaudi::GaudiAlgLib k4FWCore::k4FWCore ${Geant4_LIBRARIES} EDM4HEP::edm4hep
                  )
 #target_include_directories(SimG4Common PUBLIC ${Geant4_INCLUDE_DIRS}
 #  $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>

--- a/SimG4Components/CMakeLists.txt
+++ b/SimG4Components/CMakeLists.txt
@@ -7,7 +7,7 @@
 file(GLOB _lib_sources src/*.cpp)
 gaudi_add_module(SimG4Components
                  SOURCES ${_lib_sources}
-                 LINK GaudiAlgLib k4FWCore::k4FWCore SimG4Common EDM4HEP::edm4hep DD4hep::DDCore SimG4Interface)
+                 LINK Gaudi::GaudiAlgLib k4FWCore::k4FWCore SimG4Common EDM4HEP::edm4hep DD4hep::DDCore SimG4Interface)
 
 
 #include(CTest)

--- a/SimG4Fast/CMakeLists.txt
+++ b/SimG4Fast/CMakeLists.txt
@@ -6,11 +6,11 @@
 file(GLOB _lib_sources src/lib/*.cpp)
 gaudi_add_library(SimG4Fast
                  SOURCES ${_lib_sources}
-                 LINK GaudiAlgLib k4FWCore::k4FWCore SimG4Common EDM4HEP::edm4hep DD4hep::DDCore SimG4Interface)
+                 LINK Gaudi::GaudiAlgLib k4FWCore::k4FWCore SimG4Common EDM4HEP::edm4hep DD4hep::DDCore SimG4Interface)
 
 
 file(GLOB _module_sources src/components/*.cpp)
 gaudi_add_module(SimG4FastPlugins
                  SOURCES ${_module_sources}
-                 LINK GaudiAlgLib k4FWCore::k4FWCore SimG4Common EDM4HEP::edm4hep DD4hep::DDCore SimG4Interface SimG4Fast)
+                 LINK Gaudi::GaudiAlgLib k4FWCore::k4FWCore SimG4Common EDM4HEP::edm4hep DD4hep::DDCore SimG4Interface SimG4Fast)
 

--- a/SimG4Full/CMakeLists.txt
+++ b/SimG4Full/CMakeLists.txt
@@ -5,7 +5,7 @@
 file(GLOB _lib_sources src/lib/*.cpp)
 gaudi_add_library(SimG4Full
                  SOURCES ${_lib_sources}
-                 LINK GaudiAlgLib k4FWCore::k4FWCore SimG4Common EDM4HEP::edm4hep ${Geant4_LIBRARIES} SimG4Interface)
+                 LINK Gaudi::GaudiAlgLib k4FWCore::k4FWCore SimG4Common EDM4HEP::edm4hep ${Geant4_LIBRARIES} SimG4Interface)
 
 #target_include_directories(SimG4Full PUBLIC ${Geant4_INCLUDE_DIRS}
 #  $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
@@ -14,4 +14,4 @@ gaudi_add_library(SimG4Full
 file(GLOB _module_sources src/components/*.cpp)
 gaudi_add_module(SimG4FullPlugins
                  SOURCES ${_module_sources}
-                 LINK GaudiAlgLib k4FWCore::k4FWCore SimG4Common EDM4HEP::edm4hep DD4hep::DDCore SimG4Interface SimG4Full)
+                 LINK Gaudi::GaudiAlgLib k4FWCore::k4FWCore SimG4Common EDM4HEP::edm4hep DD4hep::DDCore SimG4Interface SimG4Full)


### PR DESCRIPTION
As already discovered in key4hep/k4FWCore#31, and fixed in key4hep/k4FWCore#32, CMake fails when trying to use `k4SimGeant4` in LCG environments. Fixes the same issue.