### PR TITLE
add sensitive detector type mapping similar to ddsim

### DIFF
--- a/Detector/DetComponents/src/GeoConstruction.cpp
+++ b/Detector/DetComponents/src/GeoConstruction.cpp
@@ -15,21 +15,25 @@
 
 namespace det {
   
-GeoConstruction::GeoConstruction(dd4hep::Detector& lcdd) : m_lcdd(lcdd) {}
+GeoConstruction::GeoConstruction(dd4hep::Detector& lcdd, std::map<std::string, std::string> sensitive_types) : m_lcdd(lcdd), m_sensitive_types(sensitive_types) {}
 
 GeoConstruction::~GeoConstruction() {}
 
 // method borrowed from dd4hep::sim::Geant4DetectorSensitivesConstruction
 //                             ::constructSensitives(Geant4DetectorConstructionContext* ctxt)
 void GeoConstruction::ConstructSDandField() {
-      typedef std::set<const TGeoVolume*> VolSet;
-      typedef std::map<dd4hep::SensitiveDetector, VolSet> _SV;
+  typedef std::set<const TGeoVolume*> VolSet;
+  typedef std::map<dd4hep::SensitiveDetector, VolSet> _SV;
   dd4hep::sim::Geant4GeometryInfo* p = dd4hep::sim::Geant4Mapping::instance().ptr();
   _SV& vols = p->sensitives;
 
   for (_SV::const_iterator iv = vols.begin(); iv != vols.end(); ++iv) {
     dd4hep::SensitiveDetector sd = (*iv).first;
-    std::string typ = sd.type(), nam = sd.name();
+    std::string typ = sd.type();
+    std::string nam = sd.name();
+    if (m_sensitive_types.find(typ) != m_sensitive_types.end()) {
+      typ = m_sensitive_types[typ];
+    }
     // Sensitive detectors are deleted in ~G4SDManager
     G4VSensitiveDetector* g4sd = dd4hep::PluginService::Create<G4VSensitiveDetector*>(typ, nam, &m_lcdd);
     if (g4sd == nullptr) {

--- a/Detector/DetComponents/src/GeoConstruction.h
+++ b/Detector/DetComponents/src/GeoConstruction.h
@@ -24,7 +24,7 @@ namespace det {
 class GeoConstruction : public G4VUserDetectorConstruction {
 public:
   /// Constructor
-  GeoConstruction(dd4hep::Detector& lcdd);
+  GeoConstruction(dd4hep::Detector& lcdd, std::map<std::string, std::string> sensitive_types);
   /// Default destructor
   virtual ~GeoConstruction();
   /// Geometry construction callback: Invoke the conversion to Geant4
@@ -36,6 +36,7 @@ public:
 private:
   /// Reference to geometry object
   dd4hep::Detector& m_lcdd;
+  std::map<std::string, std::string> m_sensitive_types;
 };
 }
 #endif /* DETDESSERVICES_GEOCONSTRUCTION_H */

--- a/Detector/DetComponents/src/GeoSvc.cpp
+++ b/Detector/DetComponents/src/GeoSvc.cpp
@@ -64,9 +64,9 @@ dd4hep::Detector* GeoSvc::lcdd() { return (m_dd4hepgeo); }
 dd4hep::DetElement GeoSvc::getDD4HepGeo() { return (lcdd()->world()); }
 
 StatusCode GeoSvc::buildGeant4Geo() {
-  std::shared_ptr<G4VUserDetectorConstruction> detector(new det::GeoConstruction(*lcdd()));
+  std::shared_ptr<G4VUserDetectorConstruction> detector(new det::GeoConstruction(*lcdd(), m_sensitive_types));
   m_geant4geo = detector;
-  if (m_geant4geo) {
+  if (nullptr != m_geant4geo) {
     return StatusCode::SUCCESS;
   } else
     return StatusCode::FAILURE;

--- a/Detector/DetComponents/src/GeoSvc.h
+++ b/Detector/DetComponents/src/GeoSvc.h
@@ -48,6 +48,8 @@ private:
   std::shared_ptr<G4VUserDetectorConstruction> m_geant4geo;
   /// XML-files with the detector description
   Gaudi::Property<std::vector<std::string>> m_xmlFileNames{this, "detectors", {}, "Detector descriptions XML-files"};
+  /// mapping of sensitive detector names
+  Gaudi::Property<std::map<std::string, std::string>> m_sensitive_types{this, "sensitiveTypes", {{"tracker", "SimpleTrackerSD"}, {"calorimeter", "SimpleCalorimeterSD"}}};
 };
 
 #endif  // GEOSVC_H


### PR DESCRIPTION
BEGINRELEASENOTES
- add sensitive detector type mapping similar to ddsim
ENDRELEASENOTES

this will replace strings like 'tracker' with the sensitive detector plugin name ('SimpleTrackerSD' for example --  this is configurable). This should let FCC use the detector constructors from LCGEO