### PR TITLE
Save CellID when saving Calo and TrackerHits

### DIFF
--- a/SimG4Components/src/SimG4SaveCalHits.cpp
+++ b/SimG4Components/src/SimG4SaveCalHits.cpp
@@ -66,16 +66,15 @@ StatusCode SimG4SaveCalHits::saveOutput(const G4Event& aEvent) {
     auto edmHits = m_caloHits.createAndPut();
     for (int iter_coll = 0; iter_coll < collections->GetNumberOfCollections(); iter_coll++) {
       collect = collections->GetHC(iter_coll);
-
-      // Add CellID encoding string to collection metadata
-      auto lcdd = m_geoSvc->lcdd();
-      auto allReadouts = lcdd->readouts();
-      auto idspec = lcdd->idSpecification(collect->GetName());
-      auto field_str = idspec.fieldDescription();
-      auto& coll_md = m_podioDataSvc->getProvider().getCollectionMetaData( m_caloHits.get()->getID() );
-      coll_md.setValue("CellIDEncodingString", field_str);
-
       if (std::find(m_readoutNames.begin(), m_readoutNames.end(), collect->GetName()) != m_readoutNames.end()) {
+        // Add CellID encoding string to collection metadata
+        auto lcdd = m_geoSvc->lcdd();
+        auto allReadouts = lcdd->readouts();
+        auto idspec = lcdd->idSpecification(collect->GetName());
+        auto field_str = idspec.fieldDescription();
+        auto& coll_md = m_podioDataSvc->getProvider().getCollectionMetaData( m_caloHits.get()->getID() );
+        coll_md.setValue("CellIDEncodingString", field_str);
+
         size_t n_hit = collect->GetSize();
         debug() << "\t" << n_hit << " hits are stored in a collection #" << iter_coll << ": " << collect->GetName()
                 << endmsg;

--- a/SimG4Components/src/SimG4SaveTrackerHits.cpp
+++ b/SimG4Components/src/SimG4SaveTrackerHits.cpp
@@ -70,16 +70,16 @@ StatusCode SimG4SaveTrackerHits::saveOutput(const G4Event& aEvent) {
     edm4hep::SimTrackerHitCollection* edmHits = m_trackHits.createAndPut();
     for (int iter_coll = 0; iter_coll < collections->GetNumberOfCollections(); iter_coll++) {
       collect = collections->GetHC(iter_coll);
-
-      // Add CellID encoding string to collection metadata
-      auto lcdd = m_geoSvc->lcdd();
-      auto allReadouts = lcdd->readouts();
-      auto idspec = lcdd->idSpecification(collect->GetName());
-      auto field_str = idspec.fieldDescription();
-      auto& coll_md = m_podioDataSvc->getProvider().getCollectionMetaData( m_trackHits.get()->getID() );
-      coll_md.setValue("CellIDEncodingString", field_str);
-
       if (std::find(m_readoutNames.begin(), m_readoutNames.end(), collect->GetName()) != m_readoutNames.end()) {
+
+        // Add CellID encoding string to collection metadata
+        auto lcdd = m_geoSvc->lcdd();
+        auto allReadouts = lcdd->readouts();
+        auto idspec = lcdd->idSpecification(collect->GetName());
+        auto field_str = idspec.fieldDescription();
+        auto& coll_md = m_podioDataSvc->getProvider().getCollectionMetaData( m_trackHits.get()->getID() );
+        coll_md.setValue("CellIDEncodingString", field_str);
+
         size_t n_hit = collect->GetSize();
         verbose() << "\t" << n_hit << " hits are stored in a tracker collection #" << iter_coll << ": "
                << collect->GetName() << endmsg;

--- a/SimG4Components/src/SimG4SaveTrackerHits.cpp
+++ b/SimG4Components/src/SimG4SaveTrackerHits.cpp
@@ -14,10 +14,6 @@
 // DD4hep
 #include "DD4hep/Detector.h"
 
-#include "DDG4/Geant4HitCollection.h"
-#include "DDG4/Geant4SensDetAction.h"
-#include "DDG4/Geant4DataConversion.h"
-
 
 DECLARE_COMPONENT(SimG4SaveTrackerHits)
 
@@ -74,15 +70,15 @@ StatusCode SimG4SaveTrackerHits::saveOutput(const G4Event& aEvent) {
     edm4hep::SimTrackerHitCollection* edmHits = m_trackHits.createAndPut();
     for (int iter_coll = 0; iter_coll < collections->GetNumberOfCollections(); iter_coll++) {
       collect = collections->GetHC(iter_coll);
-      try {
-        dd4hep::sim::Geant4HitCollection* coll = dynamic_cast<dd4hep::sim::Geant4HitCollection*>(collect);
-        dd4hep::sim::Geant4Sensitive* sd = coll->sensitive();
-        std::string sd_enc = dd4hep::sim::Geant4ConversionHelper::encoding(sd->sensitiveDetector());
-        auto& collmd = m_podioDataSvc->getProvider().getCollectionMetaData( m_trackHits.get()->getID() );
-        collmd.setValue("CellIDEncodingString", sd_enc);
-      } catch (const std::exception& e) {
-        std::cout << e.what();
-      }
+
+      // Add CellID encoding string to collection metadata
+      auto lcdd = m_geoSvc->lcdd();
+      auto allReadouts = lcdd->readouts();
+      auto idspec = lcdd->idSpecification(collect->GetName());
+      auto field_str = idspec.fieldDescription();
+      auto& coll_md = m_podioDataSvc->getProvider().getCollectionMetaData( m_trackHits.get()->getID() );
+      coll_md.setValue("CellIDEncodingString", field_str);
+
       if (std::find(m_readoutNames.begin(), m_readoutNames.end(), collect->GetName()) != m_readoutNames.end()) {
         size_t n_hit = collect->GetSize();
         verbose() << "\t" << n_hit << " hits are stored in a tracker collection #" << iter_coll << ": "


### PR DESCRIPTION
- When saving CaloHits and TrackerHits, the CellID information is missing.
- Use PodioDataSvc to retrieve the metadata and write there CellID encoding.