### PR TITLE
Adapt to new (v00-15) podio generated class names

### DIFF
--- a/Detector/DetComponents/src/MergeCells.cpp
+++ b/Detector/DetComponents/src/MergeCells.cpp
@@ -83,7 +83,7 @@ StatusCode MergeCells::execute() {
   uint debugIter = 0;
 
   for (const auto& hit : *inHits) {
-    edm4hep::CalorimeterHit newHit = outHits->create();
+    auto newHit = outHits->create();
     newHit.setEnergy(hit.getEnergy());
     newHit.setEnergyError(hit.getEnergyError());
     newHit.setPosition(hit.getPosition());

--- a/Detector/DetComponents/src/MergeLayers.cpp
+++ b/Detector/DetComponents/src/MergeLayers.cpp
@@ -80,7 +80,7 @@ StatusCode MergeLayers::execute() {
   unsigned int debugIter = 0;
 
   for (const auto& hit : *inHits) {
-    edm4hep::CalorimeterHit newHit = outHits->create();
+    auto newHit = outHits->create();
     newHit.setEnergy(hit.getEnergy());
     newHit.setEnergyError(hit.getEnergyError());
     newHit.setPosition(hit.getPosition());

--- a/Detector/DetComponents/src/RedoSegmentation.cpp
+++ b/Detector/DetComponents/src/RedoSegmentation.cpp
@@ -83,7 +83,7 @@ StatusCode RedoSegmentation::execute() {
   dd4hep::DDSegmentation::CellID oldid = 0;
   uint debugIter = 0;
   for (const auto& hit : *inHits) {
-    edm4hep::SimCalorimeterHit newHit = outHits->create();
+    auto newHit = outHits->create();
     newHit.setEnergy(hit.getEnergy());
     // SimCalorimeterHit type (needed for createCaloCells which runs after RedoSegmentation) has no time member
     //newHit.setTime(hit.getTime());

--- a/Detector/DetComponents/src/RewriteBitfield.cpp
+++ b/Detector/DetComponents/src/RewriteBitfield.cpp
@@ -79,7 +79,7 @@ StatusCode RewriteBitfield::execute() {
   uint64_t oldid = 0;
   uint debugIter = 0;
   for (const auto& hit : *inHits) {
-    edm4hep::CalorimeterHit newHit = outHits->create();
+    auto newHit = outHits->create();
     newHit.setEnergy(hit.getEnergy());
     newHit.setTime(hit.getTime());
     dd4hep::DDSegmentation::CellID cID = hit.getCellID();

--- a/SimG4Common/include/SimG4Common/ParticleInformation.h
+++ b/SimG4Common/include/SimG4Common/ParticleInformation.h
@@ -29,7 +29,6 @@ public:
    *  @param[in] aMCpart EDM MCParticle.
    */
   explicit ParticleInformation(const edm4hep::MCParticle& aMCpart);
-  explicit ParticleInformation(edm4hep::ConstMCParticle& aMCpart);
   /// A destructor
   virtual ~ParticleInformation();
   /// A printing method
@@ -37,7 +36,7 @@ public:
   /** Getter of the MCParticle.
    *  @returns EDM MCParticle.
    */
-  edm4hep::ConstMCParticle& mcParticle();
+  edm4hep::MCParticle& mcParticle();
   /** Setter of the end-of-tracking momentum (used for fast simulation).
    *  @param[in] aMom Particle momentum.
    */
@@ -73,7 +72,7 @@ public:
 
 private:
   /// EDM MC particle
-  edm4hep::ConstMCParticle m_mcParticle;
+  edm4hep::MCParticle m_mcParticle;
   /// Particle momentum at the end of tracking (filled for fast-sim)
   CLHEP::Hep3Vector m_endMomentum;
   /// Particle vertex position saved at the end of tracking (filled for fast-sim)

--- a/SimG4Common/src/ParticleInformation.cpp
+++ b/SimG4Common/src/ParticleInformation.cpp
@@ -3,13 +3,11 @@
 namespace sim {
 ParticleInformation::ParticleInformation(const edm4hep::MCParticle& aMCpart) : m_mcParticle(aMCpart), m_smeared(false) {}
 
-ParticleInformation::ParticleInformation(edm4hep::ConstMCParticle& aMCpart) : m_smeared(false) {
-  m_mcParticle = aMCpart.clone();}
 ParticleInformation::~ParticleInformation() {}
 
 void ParticleInformation::Print() const {}
 
-edm4hep::ConstMCParticle& ParticleInformation::mcParticle() { return m_mcParticle; }
+edm4hep::MCParticle& ParticleInformation::mcParticle() { return m_mcParticle; }
 void ParticleInformation::setEndMomentum(const CLHEP::Hep3Vector& aMom) { m_endMomentum = aMom; }
 const CLHEP::Hep3Vector& ParticleInformation::endMomentum() const { return m_endMomentum; }
 void ParticleInformation::setVertexPosition(const CLHEP::Hep3Vector& aPos) { m_vertexPosition = aPos; }

--- a/SimG4Components/src/SimG4SaveCalHits.cpp
+++ b/SimG4Components/src/SimG4SaveCalHits.cpp
@@ -80,7 +80,7 @@ StatusCode SimG4SaveCalHits::saveOutput(const G4Event& aEvent) {
                 << endmsg;
         for (size_t iter_hit = 0; iter_hit < n_hit; iter_hit++) {
           hit = dynamic_cast<k4::Geant4CaloHit*>(collect->GetHit(iter_hit));
-          edm4hep::SimCalorimeterHit edmHit = edmHits->create();
+          auto edmHit = edmHits->create();
           edmHit.setCellID(hit->cellID);
           //todo
           //edmHitCore.bits = hit->trackId;

--- a/SimG4Components/src/SimG4SaveSmearedParticles.cpp
+++ b/SimG4Components/src/SimG4SaveSmearedParticles.cpp
@@ -40,9 +40,9 @@ StatusCode SimG4SaveSmearedParticles::saveOutput(const G4Event& aEvent) {
       const G4PrimaryParticle* g4particle = aEvent.GetPrimaryVertex(i)->GetPrimary(j);
       sim::ParticleInformation* info = dynamic_cast<sim::ParticleInformation*>(g4particle->GetUserInformation());
       if (info->smeared()) {
-        edm4hep::ConstMCParticle& MCparticle = info->mcParticle();
-        edm4hep::ReconstructedParticle particle = particles->create();
-        edm4hep::MCRecoParticleAssociation association = associations->create();
+        auto & MCparticle = info->mcParticle();
+        auto particle = particles->create();
+        auto association = associations->create();
         association.setRec(particle);
         association.setSim(MCparticle);
         particle.setCharge(g4particle->GetCharge());

--- a/SimG4Components/src/SimG4SaveTrackerHits.cpp
+++ b/SimG4Components/src/SimG4SaveTrackerHits.cpp
@@ -85,7 +85,7 @@ StatusCode SimG4SaveTrackerHits::saveOutput(const G4Event& aEvent) {
                << collect->GetName() << endmsg;
         for (size_t iter_hit = 0; iter_hit < n_hit; iter_hit++) {
           hit = dynamic_cast<k4::Geant4PreDigiTrackHit*>(collect->GetHit(iter_hit));
-          edm4hep::SimTrackerHit edmHit = edmHits->create();
+          auto edmHit = edmHits->create();
           edmHit.setCellID(hit->cellID);
           edmHit.setEDep(hit->energyDeposit * sim::g42edm::energy);
           /// workaround, store trackid in an unrelated field

--- a/SimG4Components/src/SimG4SaveTrajectory.cpp
+++ b/SimG4Components/src/SimG4SaveTrajectory.cpp
@@ -40,7 +40,7 @@ StatusCode SimG4SaveTrajectory::saveOutput(const G4Event& aEvent) {
     G4VTrajectory* theTrajectory =  (*trajectoryContainer)[trajectoryIndex];
     for (int pointIndex = 0; pointIndex < theTrajectory->GetPointEntries(); ++pointIndex) {
       auto trajectoryPoint = theTrajectory->GetPoint(pointIndex)->GetPosition();
-      edm4hep::TrackerHit edmHit = edmPositions->create();
+      auto edmHit = edmPositions->create();
       edmHit.setCellID(0);
       edmHit.setEDep(0);
       edmHit.setTime(0);

--- a/SimG4Components/src/SimG4SingleParticleGeneratorTool.cpp
+++ b/SimG4Components/src/SimG4SingleParticleGeneratorTool.cpp
@@ -100,7 +100,7 @@ G4Event* SimG4SingleParticleGeneratorTool::g4Event() {
 StatusCode SimG4SingleParticleGeneratorTool::saveToEdm(const G4PrimaryVertex* aVertex,
                                                        const G4PrimaryParticle* aParticle) {
   edm4hep::MCParticleCollection* particles = new edm4hep::MCParticleCollection();
-  edm4hep::MCParticle particle = particles->create();
+  auto particle = particles->create();
   particle.setVertex({
        aVertex->GetX0() * sim::g42edm::length,
        aVertex->GetY0() * sim::g42edm::length,

--- a/SimG4Components/src/SimG4SmearGenParticles.cpp
+++ b/SimG4Components/src/SimG4SmearGenParticles.cpp
@@ -47,7 +47,7 @@ StatusCode SimG4SmearGenParticles::execute() {
       
       // todo: replace with copy / ctor method when available in podio
       // relations currently  not set!
-      edm4hep::MCParticle particle;
+      auto particle = particles->create();
       particle.setCharge(j.getCharge());
       particle.setPDG(j.getPDG());
       particle.setMass(j.getMass());
@@ -71,7 +71,6 @@ StatusCode SimG4SmearGenParticles::execute() {
       });
       
       n_part++;
-      particles->push_back(particle);
     }
   }
   


### PR DESCRIPTION
- Replace some dedicated types with  and rename others (Cluster -> MutableCluster, ConstCluster -> Cluster) to adapt to the new naming scheme introduced in AIDASoft/podio#205.