### PR TITLE
Only create VolumeManager when needed

### DIFF
--- a/Detector/DetComponents/src/GeoConstruction.cpp
+++ b/Detector/DetComponents/src/GeoConstruction.cpp
@@ -76,7 +76,9 @@ G4VPhysicalVolume* GeoConstruction::Construct() {
   g4map.attach(geo_info);
   // All volumes are deleted in ~G4PhysicalVolumeStore()
   G4VPhysicalVolume* m_world = geo_info->world();
-  m_lcdd.apply("DD4hepVolumeManager", 0, 0);
+  if(not m_lcdd.volumeManager().isValid()) {
+    m_lcdd.apply("DD4hepVolumeManager", 0, 0);
+  }
   // Create Geant4 volume manager
   g4map.volumeManager();
   return m_world;

--- a/Detector/DetComponents/src/GeoSvc.cpp
+++ b/Detector/DetComponents/src/GeoSvc.cpp
@@ -53,8 +53,9 @@ StatusCode GeoSvc::buildDD4HepGeo() {
     info() << "loading geometry from file:  '" << filename << "'" << endmsg;
     m_dd4hepgeo->fromCompact(filename);
   }
-  m_dd4hepgeo->volumeManager();
-  m_dd4hepgeo->apply("DD4hepVolumeManager", 0, 0);
+  if(not m_dd4hepgeo->volumeManager().isValid()) {
+    m_dd4hepgeo->apply("DD4hepVolumeManager", 0, 0);
+  }
 
   return StatusCode::SUCCESS;
 }


### PR DESCRIPTION
Make the creation of DD4hepVolumeManager only run when there isn't already one present.
Potentially saves quite some time.