### PR TITLE
Reduce the verbosity of Geant4 Physics lists printouts

### DIFF
--- a/SimG4Components/src/SimG4FtfpBert.cpp
+++ b/SimG4Components/src/SimG4FtfpBert.cpp
@@ -19,5 +19,5 @@ StatusCode SimG4FtfpBert::finalize() { return AlgTool::finalize(); }
 
 G4VModularPhysicsList* SimG4FtfpBert::physicsList() {
   // ownership passed to SimG4Svc which will register it in G4RunManager. To be deleted in ~G4RunManager()
-  return new FTFP_BERT;
+  return new FTFP_BERT(m_G4PhysicsVerbosityLevel);
 }

--- a/SimG4Components/src/SimG4FtfpBert.h
+++ b/SimG4Components/src/SimG4FtfpBert.h
@@ -29,6 +29,8 @@ public:
    *  @return pointer to G4VModularPhysicsList (ownership is transferred to the caller)
    */
   virtual G4VModularPhysicsList* physicsList();
+private:
+  Gaudi::Property<int> m_G4PhysicsVerbosityLevel{this, "G4PhysicsVerbosityLevel", 0, "Verbosity of G4 Physics printouts. 0: no printouts. 1: Verbose Printouts"};
 };
 
 #endif /* SIMG4COMPONENTS_G4FTFPBERT_H */


### PR DESCRIPTION
By default, the G4 physics list FTFP_BERT (that is usually used) will print a fairly long printout that is not captured by framework logging. It looks something like this:

```
 hInelastic FTFP_BERT : threshold between BERT and FTFP is over the interval
 for pions :   3 to 6 GeV
 for kaons :   3 to 6 GeV
 for proton :  3 to 6 GeV
 for neutron : 3 to 6 GeV

=======================================================================
======                 Electromagnetic Physics Parameters      ========
=======================================================================
LPM effect enabled                                 1
Enable creation and use of sampling tables         0
Apply cuts on all EM processes                     0
Use general process                                0
...
```

This info may be good to have, but is the same for (unchanged) physics list of the same geant4 versions. For better readability of the logs, we make this optional, with default off.