### PR TITLE
cmake: missing link DetComponents to DDRec

### DIFF
--- a/Detector/DetComponents/CMakeLists.txt
+++ b/Detector/DetComponents/CMakeLists.txt
@@ -15,6 +15,7 @@ gaudi_add_module(DetComponents
                       ROOT::Hist
                       DD4hep::DDCore
                       DD4hep::DDG4
+                      DD4hep::DDRec
                 )
 
 install(TARGETS DetComponents


### PR DESCRIPTION
Necessary as dd4hep::rec::MaterialManager::materialsBetween is used. Strangely, this only gives an error on macOS and not on the Linux builds.