### PR TITLE
Switch to Legacy services for Frame switch over

### DIFF
--- a/Detector/DetComponents/src/RedoSegmentation.cpp
+++ b/Detector/DetComponents/src/RedoSegmentation.cpp
@@ -40,7 +40,7 @@ StatusCode RedoSegmentation::initialize() {
   // Take readout, bitfield from GeoSvc
   m_oldDecoder = m_geoSvc->lcdd()->readout(m_oldReadoutName).idSpec().decoder();
   StatusCode sc_dataSvc = m_eventDataSvc.retrieve();
-  m_podioDataSvc = dynamic_cast<PodioDataSvc*>(m_eventDataSvc.get());
+  m_podioDataSvc = dynamic_cast<PodioLegacyDataSvc*>(m_eventDataSvc.get());
   if (sc_dataSvc == StatusCode::FAILURE) {
     error() << "Error retrieving Event Data Service" << endmsg;
     return StatusCode::FAILURE;

--- a/Detector/DetComponents/src/RedoSegmentation.h
+++ b/Detector/DetComponents/src/RedoSegmentation.h
@@ -63,7 +63,7 @@ private:
   uint64_t volumeID(uint64_t aCellId) const;
   /// Pointer to the geometry service
   ServiceHandle<IGeoSvc> m_geoSvc;
-  PodioDataSvc* m_podioDataSvc;
+  PodioLegacyDataSvc* m_podioDataSvc;
   ServiceHandle<IDataProviderSvc> m_eventDataSvc;
   /// Handle for the EDM positioned hits to be read
   DataHandle<edm4hep::CalorimeterHitCollection> m_inHits{"hits/caloInHits", Gaudi::DataHandle::Reader, this};

--- a/SimG4Components/src/SimG4SaveCalHits.cpp
+++ b/SimG4Components/src/SimG4SaveCalHits.cpp
@@ -48,7 +48,7 @@ StatusCode SimG4SaveCalHits::initialize() {
   }
 
   StatusCode sc = m_eventDataSvc.retrieve();
-  m_podioDataSvc = dynamic_cast<PodioDataSvc*>(m_eventDataSvc.get());
+  m_podioDataSvc = dynamic_cast<PodioLegacyDataSvc*>(m_eventDataSvc.get());
   if (sc == StatusCode::FAILURE) {
     error() << "Error retrieving Event Data Service" << endmsg;
     return StatusCode::FAILURE;

--- a/SimG4Components/src/SimG4SaveCalHits.h
+++ b/SimG4Components/src/SimG4SaveCalHits.h
@@ -49,7 +49,7 @@ private:
   /// Pointer to the geometry service
   ServiceHandle<IGeoSvc> m_geoSvc;
   /// Pointer to Podio and Event Data Services
-  PodioDataSvc* m_podioDataSvc;
+  PodioLegacyDataSvc* m_podioDataSvc;
   ServiceHandle<IDataProviderSvc> m_eventDataSvc;
   /// Handle for calo hits
   DataHandle<edm4hep::SimCalorimeterHitCollection> m_caloHits{"CaloHits", Gaudi::DataHandle::Writer, this};

--- a/SimG4Components/src/SimG4SaveTrackerHits.cpp
+++ b/SimG4Components/src/SimG4SaveTrackerHits.cpp
@@ -51,7 +51,7 @@ StatusCode SimG4SaveTrackerHits::initialize() {
   }
 
   StatusCode sc = m_eventDataSvc.retrieve();
-  m_podioDataSvc = dynamic_cast<PodioDataSvc*>(m_eventDataSvc.get());
+  m_podioDataSvc = dynamic_cast<PodioLegacyDataSvc*>(m_eventDataSvc.get());
   if (sc == StatusCode::FAILURE) {
     error() << "Error retrieving Event Data Service" << endmsg;
     return StatusCode::FAILURE;

--- a/SimG4Components/src/SimG4SaveTrackerHits.h
+++ b/SimG4Components/src/SimG4SaveTrackerHits.h
@@ -50,7 +50,7 @@ private:
   /// Pointer to the geometry service
   ServiceHandle<IGeoSvc> m_geoSvc;
   /// Pointer to Podio and Event Data Services
-  PodioDataSvc* m_podioDataSvc;
+  PodioLegacyDataSvc* m_podioDataSvc;
   ServiceHandle<IDataProviderSvc> m_eventDataSvc;
   /// Handle for tracker hits
   DataHandle<edm4hep::SimTrackerHitCollection> m_trackHits{"TrackerHits", Gaudi::DataHandle::Writer, this};

--- a/SimG4Components/tests/options/xAngleBoost.py
+++ b/SimG4Components/tests/options/xAngleBoost.py
@@ -7,7 +7,7 @@ ApplicationMgr().EvtSel = 'NONE'
 ApplicationMgr().EvtMax = 2
 ApplicationMgr().OutputLevel = INFO
 
-from Configurables import k4DataSvc
+from Configurables import k4LegacyDataSvc
 podioevent = k4DataSvc("EventDataSvc")
 ApplicationMgr().ExtSvc += [podioevent]
 


### PR DESCRIPTION
key4hep/k4FWCore#100 makes the default DataSvc use the Frame, and some of the interfaces for accessing meta data (e.g. cellID strings) will change. For a smoother transition switch this to keep using the current (`Legacy`) DataSvc and clean up again after the interface for accessing meta data has been implemented in the Frame based I/O model.

NOTE: This will fail to build until key4hep/k4FWCore#100 is merged.