### PR TITLE
Link also to k4FWCore::Interface

### DIFF
--- a/SimG4Components/CMakeLists.txt
+++ b/SimG4Components/CMakeLists.txt
@@ -8,6 +8,7 @@ gaudi_add_module(SimG4Components
                  SOURCES ${_lib_sources}
                  LINK Gaudi::GaudiAlgLib
                       k4FWCore::k4FWCore
+                      k4FWCore::k4Interface
                       SimG4Common
                       EDM4HEP::edm4hep
                       DD4hep::DDCore


### PR DESCRIPTION
When building together (at the same time) k4FWCore and k4SimGeant4, the components in SimG4Components complain about not finding the k4Interface headers. Probably this doesn't fail in regular builds (k4FWCore first and then k4SimGeant4) because there is some .cmake file telling cmake where to find these files but this extra line shouldn't change anything in the regular builds.