### PR TITLE
Use PublicToolHandleArray for save tools

### DIFF
--- a/SimG4Components/src/SimG4Alg.cpp
+++ b/SimG4Components/src/SimG4Alg.cpp
@@ -20,13 +20,12 @@ StatusCode SimG4Alg::initialize() {
     error() << "Unable to locate Geant Simulation Service" << endmsg;
     return StatusCode::FAILURE;
   }
-  for (auto& toolname : m_saveToolNames) {
-    m_saveTools.push_back(tool<ISimG4SaveOutputTool>(toolname));
-    // FIXME: check StatusCode once the m_saveTools is a ToolHandleArray
-    // if (!) {
-    //   error() << "Unable to retrieve the output saving tool." << endmsg;
-    //   return StatusCode::FAILURE;
-    // }
+  for (auto& saveTool : m_saveTools) {
+    if(!saveTool.retrieve()) {
+      error() << "Unable to retrieve the output saving tool " << saveTool
+              << endmsg;
+      return StatusCode::FAILURE;
+    }
   }
   if (!m_eventTool.retrieve()) {
     error() << "Unable to retrieve the G4Event provider " << m_eventTool << endmsg;

--- a/SimG4Components/src/SimG4Alg.h
+++ b/SimG4Components/src/SimG4Alg.h
@@ -53,12 +53,10 @@ private:
   /// Pointer to the interface of Geant simulation service
   ServiceHandle<ISimG4Svc> m_geantSvc;
   /// Handle to the tools saving the output
-  /// to be replaced with the ToolHandleArray<ISimG4SaveOutputTool> m_saveTools
-  std::vector<ISimG4SaveOutputTool*> m_saveTools;
-  /// Names for the saving tools
-  /// to be deleted once the ToolHandleArray<ISimG4SaveOutputTool> m_saveTools is in place
-  Gaudi::Property<std::vector<std::string>> m_saveToolNames{this, "outputs", {}, "Names for the saving tools"};
-  /// Handle for tool that creates the G4Event
-  ToolHandle<ISimG4EventProviderTool> m_eventTool{"SimG4PrimariesFromEdmTool", this};
+  PublicToolHandleArray<ISimG4SaveOutputTool> m_saveTools {
+      this, "outputs", {}};
+  /// Handle for the tool that creates the G4Event
+  ToolHandle<ISimG4EventProviderTool> m_eventTool{
+      "SimG4PrimariesFromEdmTool", this};
 };
 #endif /* SIMG4COMPONENTS_G4SIMALG_H */


### PR DESCRIPTION
Replaces `m_saveToolNames` (vector of strings) and `m_saveTools` (vector of tools) with `PublicToolHandleArray `.