### PR TITLE
Remove the deprecated lcdd()

### DIFF
--- a/Detector/DetComponents/src/GeoSvc.cpp
+++ b/Detector/DetComponents/src/GeoSvc.cpp
@@ -84,8 +84,6 @@ StatusCode GeoSvc::buildDD4HepGeo() {
   return StatusCode::SUCCESS;
 }
 
-dd4hep::Detector* GeoSvc::lcdd() { return m_dd4hepgeo; }
-
 dd4hep::Detector* GeoSvc::getDetector() { return m_dd4hepgeo; }
 
 dd4hep::DetElement GeoSvc::getDD4HepGeo() { return m_dd4hepgeo->world(); }

--- a/Detector/DetComponents/src/GeoSvc.h
+++ b/Detector/DetComponents/src/GeoSvc.h
@@ -37,8 +37,6 @@ public:
   StatusCode buildGeant4Geo();
   // receive DD4hep Geometry
   virtual dd4hep::DetElement getDD4HepGeo() override;
-  [[deprecated("Use getDetector() instead")]]
-  virtual dd4hep::Detector* lcdd() override;
   virtual dd4hep::Detector* getDetector() override;
   virtual std::string constantAsString(std::string const& name) override;
   // receive Geant4 Geometry


### PR DESCRIPTION
Deprecated in https://github.com/key4hep/k4FWCore/pull/142, fixes a couple of
compile warnings and I think no one downstream is using this.