### PR TITLE
Remove the explicit mentioning of momentum types

### DIFF
--- a/SimG4Components/src/SimG4PrimariesFromEdmTool.cpp
+++ b/SimG4Components/src/SimG4PrimariesFromEdmTool.cpp
@@ -32,13 +32,13 @@ G4Event* SimG4PrimariesFromEdmTool::g4Event() {
   auto theEvent = new G4Event();
   const edm4hep::MCParticleCollection* mcparticles = m_genParticles.get();
   for (auto mcparticle : *mcparticles) {
-    const edm4hep::Vector3d v = mcparticle.getVertex();
-    G4PrimaryVertex* g4Vertex = new G4PrimaryVertex(v.x * sim::edm2g4::length,
+    const auto& v = mcparticle.getVertex();
+    auto* g4Vertex = new G4PrimaryVertex(v.x * sim::edm2g4::length,
                                                     v.y * sim::edm2g4::length,
                                                     v.z * sim::edm2g4::length,
                                                     mcparticle.getTime() / Gaudi::Units::c_light  * sim::edm2g4::length);
-    const edm4hep::Vector3f mom = mcparticle.getMomentum();
-    G4PrimaryParticle* g4Particle = new G4PrimaryParticle(mcparticle.getPDG(),
+    const auto& mom = mcparticle.getMomentum();
+    auto* g4Particle = new G4PrimaryParticle(mcparticle.getPDG(),
                                                           mom.x * sim::edm2g4::energy,
                                                           mom.y * sim::edm2g4::energy,
                                                           mom.z * sim::edm2g4::energy);


### PR DESCRIPTION
Remove the explicit mentioning of the momentum type for MCParticles to ease transitions to different representations, as in key4hep/EDM4hep#237