### PR TITLE
Reorder linked libraries

### DIFF
--- a/Detector/DetComponents/CMakeLists.txt
+++ b/Detector/DetComponents/CMakeLists.txt
@@ -6,16 +6,17 @@
 file(GLOB _sources src/*.cpp)
 gaudi_add_module(DetComponents
                  SOURCES ${_sources}
-                 LINK k4FWCore::k4FWCore
+                 LINK
+                      DD4hep::DDCore
+                      DD4hep::DDG4
+                      DD4hep::DDRec
+                      k4FWCore::k4FWCore
                       k4FWCore::k4Interface
                       Gaudi::GaudiAlgLib
                       Gaudi::GaudiKernel
                       EDM4HEP::edm4hep
                       ROOT::Core
                       ROOT::Hist
-                      DD4hep::DDCore
-                      DD4hep::DDG4
-                      DD4hep::DDRec
 )
 
 install(TARGETS DetComponents

--- a/Detector/DetStudies/CMakeLists.txt
+++ b/Detector/DetStudies/CMakeLists.txt
@@ -5,21 +5,20 @@
 
 find_package(ROOT COMPONENTS MathCore GenVector Geom Tree)
 
-find_package(CLHEP)
-
-
 #--- Add main module
 file(GLOB _sources src/components/*.cpp)
 gaudi_add_module(DetStudies
                  SOURCES ${_sources}
-                 LINK k4FWCore::k4FWCore
+                 LINK
+                      DD4hep::DDCore
+                      DD4hep::DDG4
+                      k4FWCore::k4FWCore
                       k4FWCore::k4Interface
                       Gaudi::GaudiAlgLib
                       Gaudi::GaudiKernel
                       EDM4HEP::edm4hep
                       ROOT::Core
                       ROOT::Hist
-                      DD4hep::DDCore
                 )
 
 install(TARGETS DetStudies

--- a/SimG4Components/CMakeLists.txt
+++ b/SimG4Components/CMakeLists.txt
@@ -6,15 +6,17 @@
 file(GLOB _lib_sources src/*.cpp)
 gaudi_add_module(SimG4Components
                  SOURCES ${_lib_sources}
-                 LINK Gaudi::GaudiAlgLib
-                      k4FWCore::k4FWCore
-                      k4FWCore::k4Interface
-                      SimG4Common
-                      EDM4HEP::edm4hep
+                 LINK
+                      CLHEP::CLHEP
                       DD4hep::DDCore
                       DD4hep::DDG4
-                      CLHEP::CLHEP
+                      ${Geant4_LIBRARIES}
+                      SimG4Common
                       SimG4Interface
+                      k4FWCore::k4FWCore
+                      k4FWCore::k4Interface
+                      EDM4HEP::edm4hep
+                      Gaudi::GaudiAlgLib
 )
 
 add_test(NAME CrossingAngleBoost

--- a/SimG4Fast/CMakeLists.txt
+++ b/SimG4Fast/CMakeLists.txt
@@ -6,11 +6,11 @@
 file(GLOB _lib_sources src/lib/*.cpp)
 gaudi_add_library(SimG4Fast
                  SOURCES ${_lib_sources}
-                 LINK Gaudi::GaudiAlgLib k4FWCore::k4FWCore SimG4Common EDM4HEP::edm4hep DD4hep::DDCore SimG4Interface)
+                 LINK DD4hep::DDCore SimG4Common SimG4Interface Gaudi::GaudiAlgLib k4FWCore::k4FWCore EDM4HEP::edm4hep)
 
 
 file(GLOB _module_sources src/components/*.cpp)
 gaudi_add_module(SimG4FastPlugins
                  SOURCES ${_module_sources}
-                 LINK Gaudi::GaudiAlgLib k4FWCore::k4FWCore SimG4Common EDM4HEP::edm4hep DD4hep::DDCore SimG4Interface SimG4Fast)
+                 LINK DD4hep::DDCore SimG4Common SimG4Interface SimG4Fast Gaudi::GaudiAlgLib k4FWCore::k4FWCore EDM4HEP::edm4hep)
 

--- a/SimG4Full/CMakeLists.txt
+++ b/SimG4Full/CMakeLists.txt
@@ -5,7 +5,7 @@
 file(GLOB _lib_sources src/lib/*.cpp)
 gaudi_add_library(SimG4Full
                  SOURCES ${_lib_sources}
-                 LINK Gaudi::GaudiAlgLib k4FWCore::k4FWCore SimG4Common EDM4HEP::edm4hep ${Geant4_LIBRARIES} SimG4Interface)
+                 LINK SimG4Common SimG4Interface Gaudi::GaudiAlgLib k4FWCore::k4FWCore EDM4HEP::edm4hep)
 
 #target_include_directories(SimG4Full PUBLIC ${Geant4_INCLUDE_DIRS}
 #  $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
@@ -14,4 +14,4 @@ gaudi_add_library(SimG4Full
 file(GLOB _module_sources src/components/*.cpp)
 gaudi_add_module(SimG4FullPlugins
                  SOURCES ${_module_sources}
-                 LINK Gaudi::GaudiAlgLib k4FWCore::k4FWCore SimG4Common EDM4HEP::edm4hep DD4hep::DDCore SimG4Interface SimG4Full)
+                 LINK SimG4Full SimG4Common SimG4Interface Gaudi::GaudiAlgLib k4FWCore::k4FWCore EDM4HEP::edm4hep)


### PR DESCRIPTION
I'm trying to install k4SimGeant4 on a system with CLHEP being the one from Geant4 and CLHEP in the system (not ideal) and compilation will fail because the system CLHEP is being picked instead of the G4 CLHEP. The reordering helps with that, putting before DD4hep when possible since it is Gaudi the one adding the system CLHEP flags.