### PR TITLE
Make sure to use the correct project name for downstream users

### DIFF
--- a/cmake/k4SimGeant4Config.cmake
+++ b/cmake/k4SimGeant4Config.cmake
@@ -8,4 +8,4 @@ find_dependency(k4FWCore REQUIRED)
 include("${CMAKE_CURRENT_LIST_DIR}/k4SimGeant4Targets.cmake")
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(k4Gen  DEFAULT_MSG CMAKE_CURRENT_LIST_FILE)
+find_package_handle_standard_args(k4SimGeant4  DEFAULT_MSG CMAKE_CURRENT_LIST_FILE)


### PR DESCRIPTION
It looks like `k4Gen` was left there by accident. This fixes the following warning that you otherwise get when consuming `k4SimGeant4` via `find_package`

```
CMake Warning (dev) at /home/tmadlener/work/.spack/spackages/cmake/3.27.9/skylake-ubuntu22.04-gcc12.3.0/ye3nv36/share/cmake-3.27/Modules/FindPackageHandleStandardArgs.cmake:438 (message):
  The package name passed to `find_package_handle_standard_args` (k4Gen) does
  not match the name of the calling package (k4SimGeant4).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  /home/tmadlener/work/.spack/spackages/k4simgeant4/main/skylake-ubuntu22.04-gcc12.3.0/dcytmfc/lib/cmake/k4SimGeant4/k4SimGeant4Config.cmake:11 (find_package_handle_standard_args)
  CMakeLists.txt:35 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Found k4Gen: /home/tmadlener/work/.spack/spackages/k4simgeant4/main/skylake-ubuntu22.04-gcc12.3.0/dcytmfc/lib/cmake/k4SimGeant4/k4SimGeant4Config.cmake  
```