### PR TITLE
Remove forward declarations to avoid conflicts

### DIFF
--- a/SimG4Components/src/SimG4SaveSmearedParticles.h
+++ b/SimG4Components/src/SimG4SaveSmearedParticles.h
@@ -8,10 +8,11 @@
 #include "k4FWCore/DataHandle.h"
 #include "SimG4Interface/ISimG4SaveOutputTool.h"
 
+#include "edm4hep/MCRecoParticleAssociationCollection.h"
+
 // datamodel
 namespace edm4hep {
 class ReconstructedParticleCollection;
-class MCRecoParticleAssociationCollection;
 }
 
 /** @class SimG4SaveSmearedParticles SimG4Components/src/SimG4SaveSmearedParticles.h SimG4SaveSmearedParticles.h

--- a/SimG4Fast/src/components/SimG4FastSimHistograms.h
+++ b/SimG4Fast/src/components/SimG4FastSimHistograms.h
@@ -8,10 +8,11 @@
 #include "k4FWCore/DataHandle.h"
 class ITHistSvc;
 
+#include "edm4hep/MCRecoParticleAssociationCollection.h"
+
 // datamodel
 namespace edm4hep {
 class ReconstructedParticleCollection;
-class MCRecoParticleAssociationCollection;
 }
 
 class TH1F;


### PR DESCRIPTION
Remove the forward declarations of `MCRecoParticleAssociation` to make it possible to introduce https://github.com/key4hep/EDM4hep/pull/341 transparently and fix the deprecation warnings later.

@BrieucF if we can merge this today, I would also merge the EDM4hep PR and tag things if the nightlies work out tomorrow.