### PR TITLE
Fix the service retrieval after deprecations in Gaudi v39r1

### DIFF
--- a/SimG4Fast/src/components/SimG4ParticleSmearSimple.cpp
+++ b/SimG4Fast/src/components/SimG4ParticleSmearSimple.cpp
@@ -1,9 +1,5 @@
 #include "SimG4ParticleSmearSimple.h"
 
-// Gaudi
-
-#include "GaudiKernel/IRndmGenSvc.h"
-
 // CLHEP
 #include "CLHEP/Vector/ThreeVector.h"
 
@@ -19,10 +15,6 @@ SimG4ParticleSmearSimple::~SimG4ParticleSmearSimple() {}
 
 StatusCode SimG4ParticleSmearSimple::initialize() {
   if (AlgTool::initialize().isFailure()) {
-    return StatusCode::FAILURE;
-  }
-  if (service("RndmGenSvc", m_randSvc).isFailure()) {
-    error() << "Couldn't get RndmGenSvc" << endmsg;
     return StatusCode::FAILURE;
   }
   m_gauss.initialize(m_randSvc, Rndm::Gauss(1, m_sigma)).ignore();

--- a/SimG4Fast/src/components/SimG4ParticleSmearSimple.cpp
+++ b/SimG4Fast/src/components/SimG4ParticleSmearSimple.cpp
@@ -14,6 +14,13 @@ SimG4ParticleSmearSimple::SimG4ParticleSmearSimple(const std::string& type, cons
 SimG4ParticleSmearSimple::~SimG4ParticleSmearSimple() {}
 
 StatusCode SimG4ParticleSmearSimple::initialize() {
+
+  m_randSvc = service("RndmGenSvc", false);
+  if (!m_randSvc) {
+    error() << "Couldn't get RndmGenSvc" << endmsg;
+    return StatusCode::FAILURE;
+  }
+
   if (AlgTool::initialize().isFailure()) {
     return StatusCode::FAILURE;
   }

--- a/SimG4Fast/src/components/SimG4ParticleSmearSimple.h
+++ b/SimG4Fast/src/components/SimG4ParticleSmearSimple.h
@@ -4,7 +4,7 @@
 // Gaudi
 #include "GaudiKernel/AlgTool.h"
 #include "GaudiKernel/RndmGenerators.h"
-class IRndmGenSvc;
+#include "GaudiKernel/IRndmGenSvc.h"
 
 // FCCSW
 #include "SimG4Interface/ISimG4ParticleSmearTool.h"
@@ -51,7 +51,7 @@ public:
 
 private:
   /// Random Number Service
-  IRndmGenSvc* m_randSvc;
+  SmartIF<IRndmGenSvc> m_randSvc;
   /// Gaussian random number generator used for smearing with a constant resolution (m_sigma)
   Rndm::Numbers m_gauss;
   /// Constant resolution for the smearing (set by job options)


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix the service retrieval after deprecations in Gaudi v39r1, see https://gitlab.cern.ch/gaudi/Gaudi/-/merge_requests/1637

ENDRELEASENOTES

Like in https://github.com/key4hep/k4FWCore/pull/256