### PR TITLE
Remove the color flow from MCParticle

### DIFF
--- a/SimG4Components/src/SimG4SmearGenParticles.cpp
+++ b/SimG4Components/src/SimG4SmearGenParticles.cpp
@@ -55,7 +55,6 @@ StatusCode SimG4SmearGenParticles::execute(const EventContext&) const {
       particle.setSimulatorStatus(j.getSimulatorStatus());
       particle.setMomentumAtEndpoint(j.getMomentumAtEndpoint());
       particle.setSpin(j.getSpin());
-      particle.setColorFlow(j.getColorFlow());
       particle.setVertex(j.getVertex());
 
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Remove the setting of `colorFlow` for MCParticles. 
  - Removed in [EDM4hep#389](https://github.com/key4hep/EDM4hep/pull/389)

ENDRELEASENOTES
