### PR TITLE
Move DataHandle and MetaDataHandle to the k4FWCore namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(ROOT COMPONENTS RIO Tree)
 #---------------------------------------------------------------
 # Load macros and functions for Gaudi-based projects
 find_package(Gaudi REQUIRED)
-find_package(k4FWCore REQUIRED)
+find_package(k4FWCore 1.3 REQUIRED)
 find_package(EDM4HEP 0.99)
 find_package(Geant4 REQUIRED)
 find_package(DD4hep REQUIRED)

--- a/Detector/DetComponents/src/MergeCells.h
+++ b/Detector/DetComponents/src/MergeCells.h
@@ -53,9 +53,11 @@ private:
   /// Pointer to the geometry service
   ServiceHandle<IGeoSvc> m_geoSvc;
   /// Handle for the EDM Hits to be read
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_inHits{"hits/caloInHits", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_inHits{"hits/caloInHits", Gaudi::DataHandle::Reader,
+                                                                           this};
   /// Handle for the EDM Hits to be written
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_outHits{"hits/caloOutHits", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_outHits{"hits/caloOutHits",
+                                                                            Gaudi::DataHandle::Writer, this};
   // Handle to the detector ID descriptor
   dd4hep::IDDescriptor m_descriptor;
   /// Name of the detector readout

--- a/Detector/DetComponents/src/MergeLayers.h
+++ b/Detector/DetComponents/src/MergeLayers.h
@@ -56,9 +56,11 @@ private:
   /// Pointer to the geometry service
   ServiceHandle<IGeoSvc> m_geoSvc;
   /// Handle for the EDM Hits to be read
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_inHits{"hits/caloInHits", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_inHits{"hits/caloInHits", Gaudi::DataHandle::Reader,
+                                                                           this};
   /// Handle for the EDM Hits to be written
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_outHits{"hits/caloOutHits", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_outHits{"hits/caloOutHits",
+                                                                            Gaudi::DataHandle::Writer, this};
   // Handle to the detector ID descriptor
   dd4hep::IDDescriptor m_descriptor;
   /// Name of the detector readout

--- a/Detector/DetComponents/src/RedoSegmentation.h
+++ b/Detector/DetComponents/src/RedoSegmentation.h
@@ -60,13 +60,14 @@ private:
   /// Pointer to the geometry service
   ServiceHandle<IGeoSvc> m_geoSvc;
   /// Handle for the EDM positioned hits to be read
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_inHits{"hits/caloInHits", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_inHits{"hits/caloInHits", Gaudi::DataHandle::Reader,
+                                                                           this};
   /// Handle for the EDM hits to be written
-  mutable DataHandle<edm4hep::SimCalorimeterHitCollection> m_outHits{"hits/caloOutHits", Gaudi::DataHandle::Writer,
-                                                                     this};
+  mutable k4FWCore::DataHandle<edm4hep::SimCalorimeterHitCollection> m_outHits{"hits/caloOutHits",
+                                                                               Gaudi::DataHandle::Writer, this};
   /// Handle for the output hits cell id encoding.
-  MetaDataHandle<std::string> m_outHitsCellIDEncoding{m_outHits, edm4hep::labels::CellIDEncoding,
-                                                      Gaudi::DataHandle::Writer};
+  k4FWCore::MetaDataHandle<std::string> m_outHitsCellIDEncoding{m_outHits, edm4hep::labels::CellIDEncoding,
+                                                                Gaudi::DataHandle::Writer};
   /// New segmentation
   dd4hep::DDSegmentation::Segmentation* m_segmentation;
   int m_segmentationType; // use enum instead? defined in some namespace?

--- a/Detector/DetComponents/src/RewriteBitfield.h
+++ b/Detector/DetComponents/src/RewriteBitfield.h
@@ -57,9 +57,11 @@ private:
   /// Pointer to the geometry service
   ServiceHandle<IGeoSvc> m_geoSvc;
   /// Handle for the EDM hits to be read
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_inHits{"hits/caloInHits", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_inHits{"hits/caloInHits", Gaudi::DataHandle::Reader,
+                                                                           this};
   /// Handle for the EDM hits to be written
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_outHits{"hits/caloOutHits", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_outHits{"hits/caloOutHits",
+                                                                            Gaudi::DataHandle::Writer, this};
   /// Name of the detector readout used in simulation
   Gaudi::Property<std::string> m_oldReadoutName{this, "oldReadoutName", "",
                                                 "Name of the detector readout used in simulation"};

--- a/Detector/DetStudies/src/components/EnergyInCaloLayers.h
+++ b/Detector/DetStudies/src/components/EnergyInCaloLayers.h
@@ -46,16 +46,20 @@ public:
 
 private:
   /// Handle for the energy deposits
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_deposits{"det/caloDeposits", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_deposits{"det/caloDeposits",
+                                                                             Gaudi::DataHandle::Reader, this};
   /// Handle for the particle
-  mutable DataHandle<edm4hep::MCParticleCollection> m_particle{"det/particles", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_particle{"det/particles", Gaudi::DataHandle::Reader,
+                                                                         this};
   /// Handle for vector with energy deposited in every layer
-  mutable DataHandle<podio::UserDataCollection<double>> m_energyInLayer{"energyInLayer", Gaudi::DataHandle::Writer,
-                                                                        this};
+  mutable k4FWCore::DataHandle<podio::UserDataCollection<double>> m_energyInLayer{"energyInLayer",
+                                                                                  Gaudi::DataHandle::Writer, this};
   /// Handle for vector with energy deposited in cryostat and in its parts
-  mutable DataHandle<podio::UserDataCollection<double>> m_energyInCryo{"energyInCryo", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<podio::UserDataCollection<double>> m_energyInCryo{"energyInCryo",
+                                                                                 Gaudi::DataHandle::Writer, this};
   /// Handle for initial particle vector
-  mutable DataHandle<podio::UserDataCollection<double>> m_particleVec{"particleVec", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<podio::UserDataCollection<double>> m_particleVec{"particleVec",
+                                                                                Gaudi::DataHandle::Writer, this};
 
   /// Pointer to the geometry service
   ServiceHandle<IGeoSvc> m_geoSvc;

--- a/Detector/DetStudies/src/components/SamplingFractionInLayers.h
+++ b/Detector/DetStudies/src/components/SamplingFractionInLayers.h
@@ -49,7 +49,8 @@ private:
   /// Pointer to the geometry service
   ServiceHandle<IGeoSvc> m_geoSvc;
   /// Handle for the energy deposits
-  mutable DataHandle<edm4hep::SimCalorimeterHitCollection> m_deposits{"rec/caloHits", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::SimCalorimeterHitCollection> m_deposits{"rec/caloHits",
+                                                                                Gaudi::DataHandle::Reader, this};
   /// Name of the active field
   Gaudi::Property<std::string> m_activeFieldName{this, "activeFieldName", "", "Identifier of active material"};
   /// Value of the active material

--- a/SimG4Components/src/SimG4CrossingAngleBoost.h
+++ b/SimG4Components/src/SimG4CrossingAngleBoost.h
@@ -39,9 +39,11 @@ public:
 
 private:
   /// Handle for the particles to be read
-  mutable DataHandle<edm4hep::MCParticleCollection> m_inParticles{"InParticles", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_inParticles{"InParticles", Gaudi::DataHandle::Reader,
+                                                                            this};
   /// Handle for the particles to be written
-  mutable DataHandle<edm4hep::MCParticleCollection> m_outParticles{"OutParticles", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_outParticles{"OutParticles", Gaudi::DataHandle::Writer,
+                                                                             this};
   /// Value of the crossing angle in radians
   Gaudi::Property<double> m_alpha{this, "CrossingAngle", 0., "Crossing angle (alpha) in radians"};
 };

--- a/SimG4Components/src/SimG4GeantinosFromEdmTool.h
+++ b/SimG4Components/src/SimG4GeantinosFromEdmTool.h
@@ -30,7 +30,8 @@ public:
 
 private:
   /// Handle for the EDM MC particles to be read
-  mutable DataHandle<edm4hep::MCParticleCollection> m_genParticles{"GenParticles", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_genParticles{"GenParticles", Gaudi::DataHandle::Reader,
+                                                                             this};
 };
 
 #endif

--- a/SimG4Components/src/SimG4PrimariesFromEdmTool.h
+++ b/SimG4Components/src/SimG4PrimariesFromEdmTool.h
@@ -37,7 +37,8 @@ public:
 
 private:
   /// Handle for the EDM MC particles to be read
-  mutable DataHandle<edm4hep::MCParticleCollection> m_genParticles{"GenParticles", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_genParticles{"GenParticles", Gaudi::DataHandle::Reader,
+                                                                             this};
 };
 
 #endif

--- a/SimG4Components/src/SimG4SaveCalHits.h
+++ b/SimG4Components/src/SimG4SaveCalHits.h
@@ -65,9 +65,11 @@ private:
   /// Pointer to the geometry service
   ServiceHandle<IGeoSvc> m_geoSvc;
   /// Output handle for calo hits
-  mutable DataHandle<edm4hep::SimCalorimeterHitCollection> m_caloHits{"CaloHits", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::SimCalorimeterHitCollection> m_caloHits{"CaloHits", Gaudi::DataHandle::Writer,
+                                                                                this};
   /// Output handle for cell ID encoding string
-  MetaDataHandle<std::string> m_cellIDEncoding{m_caloHits, edm4hep::labels::CellIDEncoding, Gaudi::DataHandle::Writer};
+  k4FWCore::MetaDataHandle<std::string> m_cellIDEncoding{m_caloHits, edm4hep::labels::CellIDEncoding,
+                                                         Gaudi::DataHandle::Writer};
   /// Name of the readouts (hits collections) to save, deprecated
   Gaudi::Property<std::vector<std::string>> m_readoutNames{
       this, "readoutNames", {}, "[Deprecated] Names of the readouts (hits collections) to save"};

--- a/SimG4Components/src/SimG4SaveParticleHistory.h
+++ b/SimG4Components/src/SimG4SaveParticleHistory.h
@@ -42,8 +42,8 @@ public:
 
 private:
   /// Handle for collection of MC particles to create
-  mutable DataHandle<edm4hep::MCParticleCollection> m_mcParticles{"SimParticleSecondaries", Gaudi::DataHandle::Writer,
-                                                                  this};
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_mcParticles{"SimParticleSecondaries",
+                                                                            Gaudi::DataHandle::Writer, this};
   /// Pointer to the particle collection, ownership should be handled in a algorithm / tool
   edm4hep::MCParticleCollection* m_mcParticleColl;
 };

--- a/SimG4Components/src/SimG4SaveSmearedParticles.h
+++ b/SimG4Components/src/SimG4SaveSmearedParticles.h
@@ -43,11 +43,11 @@ public:
 
 private:
   /// Handle for the particles to be written
-  mutable DataHandle<edm4hep::ReconstructedParticleCollection> m_particles{"RecParticlesSmeared",
-                                                                           Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::ReconstructedParticleCollection> m_particles{"RecParticlesSmeared",
+                                                                                     Gaudi::DataHandle::Writer, this};
   /// Handle for the associations between particles and MC particles to be written
-  mutable DataHandle<edm4hep::RecoMCParticleLinkCollection> m_particlesMCparticles{"SmearedParticlesToParticles",
-                                                                                   Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::RecoMCParticleLinkCollection> m_particlesMCparticles{
+      "SmearedParticlesToParticles", Gaudi::DataHandle::Writer, this};
 };
 
 #endif /* SIMG4COMPONENTS_G4SAVESMEAREDPARTICLES_H */

--- a/SimG4Components/src/SimG4SaveTrackerHits.h
+++ b/SimG4Components/src/SimG4SaveTrackerHits.h
@@ -66,9 +66,11 @@ private:
   /// Pointer to the geometry service
   ServiceHandle<IGeoSvc> m_geoSvc;
   /// Handle for output tracker hits
-  mutable DataHandle<edm4hep::SimTrackerHitCollection> m_trackHits{"TrackerHits", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::SimTrackerHitCollection> m_trackHits{"TrackerHits", Gaudi::DataHandle::Writer,
+                                                                             this};
   /// Output handle for cell ID encoding string
-  MetaDataHandle<std::string> m_cellIDEncoding{m_trackHits, edm4hep::labels::CellIDEncoding, Gaudi::DataHandle::Writer};
+  k4FWCore::MetaDataHandle<std::string> m_cellIDEncoding{m_trackHits, edm4hep::labels::CellIDEncoding,
+                                                         Gaudi::DataHandle::Writer};
   /// Names of the readouts (hits collections) to save, deprecated
   Gaudi::Property<std::vector<std::string>> m_readoutNames{
       this, "readoutNames", {}, "[Deprecated] Name of the readouts (hits collections) to save"};

--- a/SimG4Components/src/SimG4SaveTrajectory.h
+++ b/SimG4Components/src/SimG4SaveTrajectory.h
@@ -40,7 +40,8 @@ private:
   /// Pointer to the geometry service
   ServiceHandle<IGeoSvc> m_geoSvc;
   /// Handle for trajectory hits including position information
-  mutable DataHandle<edm4hep::TrackerHit3DCollection> m_trackHits{"Hits/Trajectory", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::TrackerHit3DCollection> m_trackHits{"Hits/Trajectory",
+                                                                            Gaudi::DataHandle::Writer, this};
 };
 
 #endif /* SIMG4COMPONENTS_G4SAVETRAJECTORY */

--- a/SimG4Components/src/SimG4SingleParticleGeneratorTool.h
+++ b/SimG4Components/src/SimG4SingleParticleGeneratorTool.h
@@ -69,8 +69,8 @@ private:
   /// Flag whether to save primary particle to EDM, set with saveEdm
   Gaudi::Property<bool> m_saveEdm{this, "saveEdm", false};
   /// Handle for the genparticles to be written
-  mutable DataHandle<edm4hep::MCParticleCollection> m_genParticlesHandle{"GenParticles", Gaudi::DataHandle::Writer,
-                                                                         this};
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_genParticlesHandle{"GenParticles",
+                                                                                   Gaudi::DataHandle::Writer, this};
 };
 
 #endif

--- a/SimG4Components/src/SimG4SmearGenParticles.h
+++ b/SimG4Components/src/SimG4SmearGenParticles.h
@@ -42,9 +42,11 @@ public:
 
 private:
   /// Handle for the particles to be written
-  mutable DataHandle<edm4hep::MCParticleCollection> m_inParticles{"GenParticles", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_inParticles{"GenParticles", Gaudi::DataHandle::Reader,
+                                                                            this};
   /// Handle for the particles to be written
-  mutable DataHandle<edm4hep::MCParticleCollection> m_particles{"SimParticlesSmeared", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_particles{"SimParticlesSmeared",
+                                                                          Gaudi::DataHandle::Writer, this};
   /// Handle for the calorimeter cells noise tool
   mutable ToolHandle<ISimG4ParticleSmearTool> m_smearTool{"SimG4ParticleSmearRootFile", this};
   /// Flag to decide on wether to only smear and write out charged particles

--- a/SimG4Fast/src/components/SimG4FastSimHistograms.h
+++ b/SimG4Fast/src/components/SimG4FastSimHistograms.h
@@ -45,8 +45,8 @@ public:
 
 private:
   /// Handle for the EDM particles and MC particles associations to be read
-  mutable DataHandle<edm4hep::RecoMCParticleLinkCollection> m_particlesMCparticles{"ParticlesMCparticles",
-                                                                                   Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::RecoMCParticleLinkCollection> m_particlesMCparticles{
+      "ParticlesMCparticles", Gaudi::DataHandle::Reader, this};
   /// Pointer to the interface of histogram service
   SmartIF<ITHistSvc> m_histSvc;
   // Histogram of the smeared particle's momentum


### PR DESCRIPTION
BEGINRELEASENOTES
- Move DataHandle and MetaDataHandle to the k4FWCore namespace, done in k4FWCore in https://github.com/key4hep/k4FWCore/pull/317
- Bump the required version of k4FWCore

ENDRELEASENOTES