### PR TITLE
Simplify and clean up GeoSvc

### DIFF
--- a/Detector/DetComponents/src/GeoSvc.cpp
+++ b/Detector/DetComponents/src/GeoSvc.cpp
@@ -6,6 +6,7 @@
 
 #include <TGeoManager.h>
 
+#include <DD4hep/Detector.h>
 #include <DD4hep/Printout.h>
 
 GeoSvc::GeoSvc(const std::string& name, ISvcLocator* svc) : base_class(name, svc) {}

--- a/Detector/DetComponents/src/GeoSvc.h
+++ b/Detector/DetComponents/src/GeoSvc.h
@@ -6,8 +6,9 @@
 
 #include "k4Interface/IGeoSvc.h"
 
-#include "DD4hep/Detector.h"
-
+namespace dd4hep {
+class Detector;
+}
 class G4VUserDetectorConstruction;
 
 class GeoSvc : public extends<Service, IGeoSvc> {


### PR DESCRIPTION
BEGINRELEASENOTES
- Simplify GeoSvc: remove a useless destructor, simplify constructor, add `const` where possible, remove obvious comments, use `!` instead of `not` remove a few extra parenthesis, only include what is being used in the header file and forward declare the rest

ENDRELEASENOTES

Locally I can run algorithms that use it fine after these changes