### PR TITLE
Refactor MaterialScan*_genericAngle into MaterialScan_2D

### DIFF
--- a/Detector/DetComponents/src/MaterialScan.h
+++ b/Detector/DetComponents/src/MaterialScan.h
@@ -1,44 +1,52 @@
 #include "k4Interface/IGeoSvc.h"
 
-#include "GaudiKernel/RndmGenerators.h"
+#include "Gaudi/Property.h"
 #include "GaudiKernel/Service.h"
 
-/** @class MaterialScan Detector/DetComponents/src/MaterialScan.h MaterialScan.h
+/**
  *
  *  Service that facilitates material scan on initialize
  *  This service outputs a ROOT file containing a TTree with radiation lengths and material thickness
- *  For an example on how to read the file, see Examples/scripts/material_plots.py
  *
- *  !!! Superseeded by MaterialScan_genericAngle.h that extends this script by the possibility
- *  to use also theta (degrees), theta (radians) or cos(theta) instead of eta. !!!
- *  @author J. Lingemann
  */
 
 class MaterialScan : public Service {
 public:
   explicit MaterialScan(const std::string& name, ISvcLocator* svcLoc);
 
-  virtual StatusCode initialize();
-  virtual StatusCode finalize();
-  virtual ~MaterialScan() {};
+  StatusCode initialize() override;
 
 private:
   /// name of the output file
   Gaudi::Property<std::string> m_filename{this, "filename", "", "file name to save the tree to"};
   /// Handle to the geometry service from which the detector is retrieved
   ServiceHandle<IGeoSvc> m_geoSvc;
-  /// Step size in eta
-  Gaudi::Property<double> m_etaBinning{this, "etaBinning", 0.05, "eta bin size"};
-  /// Maximum eta until which to scan, scan is performed from -m_etaMax to +m_etaMax
-  Gaudi::Property<double> m_etaMax{this, "etaMax", 6, "maximum eta value"};
-  /// number of random, uniformly distributed phi values to average over
-  Gaudi::Property<double> m_nPhiTrials{this, "nPhiTrials", 100,
-                                       "number of random, uniformly distributed phi values to average over"};
+
+  /// Step size in eta (deprecated, use angleBinning instead)
+  Gaudi::Property<double> m_etaBinning{this, "etaBinning", -1, "eta bin size"};
+  /// Step size in eta/theta/cosTheta/thetaRad
+  Gaudi::Property<double> m_angleBinning{this, "angleBinning", 0.05, "eta/theta/cosTheta/thetaRad bin size"};
+
+  /// Maximum eta until which to scan, scan is performed from -m_etaMax to +m_etaMax (deprecated, use angleMax instead)
+  Gaudi::Property<double> m_etaMax{this, "etaMax", -1, "maximum eta value"};
+  /// Maximum eta/theta/cosTheta/thetaRad until which to scan
+  Gaudi::Property<double> m_angleMax{this, "angleMax", 6, "maximum eta/theta/cosTheta/thetaRad value"};
+
+  /// Minimum eta/theta/cosTheta/thetaRad until which to scan
+  Gaudi::Property<double> m_angleMin{this, "angleMin", -6, "minimum eta/theta/cosTheta/thetaRad value"};
+
+  /// number of random, uniformly distributed phi values to average over (deprecated, use nPhi instead)
+  Gaudi::Property<int> m_nPhiTrials{this, "nPhiTrials", -1,
+                                    "number of random, uniformly distributed phi values to average over"};
+  /// number of phi values to run over, evenly distributed from 0 to 2 pi
+  Gaudi::Property<int> m_nPhi{this, "nPhi", 100, "number of phi values to run over, evenly distributed from 0 to 2 pi"};
+
+  /// angle definition to use: eta, theta, cosTheta or thetaRad default: eta
+  Gaudi::Property<std::string> m_angleDef{
+      this, "angleDef", "eta",
+      "angle definition to use: 'eta', 'theta' (in degrees), 'cosTheta' or 'thetaRad' (in rad)"};
+
   /// Name of the envelope within which the material is measured (by default: world volume)
   Gaudi::Property<std::string> m_envelopeName{this, "envelopeName", "world",
                                               "name of the envelope within which the material is measured"};
-  /// Flat random number generator
-  Rndm::Numbers m_flatPhiDist;
-  /// Flat random number generator
-  Rndm::Numbers m_flatEtaDist;
 };

--- a/Detector/DetComponents/src/MaterialScan_2D_genericAngle.cpp
+++ b/Detector/DetComponents/src/MaterialScan_2D_genericAngle.cpp
@@ -29,6 +29,10 @@ StatusCode MaterialScan_2D_genericAngle::initialize() {
     return StatusCode::FAILURE;
   }
 
+  warning() << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << endmsg;
+  warning() << "MaterialScan_2D_genericAngle is deprecated, use MaterialScan instead." << endmsg;
+  warning() << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << endmsg;
+
   std::list<std::string> allowed_angleDef = {"eta", "theta", "thetaRad", "cosTheta"};
   if (std::find(allowed_angleDef.begin(), allowed_angleDef.end(), m_angleDef) == allowed_angleDef.end()) {
     error() << "Non valid angleDef option given. Use either 'eta', 'theta', 'thetaRad' or 'cosTheta'!" << endmsg;

--- a/Detector/DetComponents/src/MaterialScan_genericAngle.cpp
+++ b/Detector/DetComponents/src/MaterialScan_genericAngle.cpp
@@ -30,6 +30,10 @@ StatusCode MaterialScan_genericAngle::initialize() {
     return StatusCode::FAILURE;
   }
 
+  warning() << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << endmsg;
+  warning() << "MaterialScan_genericAngle is deprecated, use MaterialScan instead." << endmsg;
+  warning() << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << endmsg;
+
   std::list<std::string> allowed_angleDef = {"eta", "theta", "thetaRad", "cosTheta"};
   if (std::find(allowed_angleDef.begin(), allowed_angleDef.end(), m_angleDef) == allowed_angleDef.end()) {
     error() << "Non valid angleDef option given. Use either 'eta', 'theta', 'thetaRad' or 'cosTheta'!" << endmsg;


### PR DESCRIPTION
The current status of things is that we have 3 different services for doing a material scan
- The original: `MaterialScan`, that only allows binning in eta
- `MaterialScan_genericAngle`: that allows binning in eta, theta, costheta and uses a random phi (only between 0 and 90 degrees)
- `MaterialScan_2D_genericAngle`: same as above, except it allows binning in phi

This is not great as the code does pretty much the same thing in all three cases with some variations. I propose then to have a single service for doing material scanning. For that, we can use `MaterialScan`, adding the properties that it doesn't have and deprecating `MaterialScan_genericAngle` and `MaterialScan_2D_genericAngle`, removing them later in the future. One key difference is that now phi will not be random like before (both in the old `MaterialScan` and `MaterialScan_genericAngle`, which in my opinion is better as I believe different results would be obtained when running multiple times.


BEGINRELEASENOTES
- Copy the code of `MaterialScan_2D_genericAngle` into `MaterialScan`, doing a bit of cleanup and preserving the old properties of `MaterialScan`, that now emit a deprecation warning if used
- Deprecate `MaterialScan_genericAngle` and `MaterialScan_2D_genericAngle`

ENDRELEASENOTES