### PR TITLE
Making IGeoSvc::getDetector and constantAsString const.

### DIFF
--- a/Detector/DetComponents/src/GeoSvc.cpp
+++ b/Detector/DetComponents/src/GeoSvc.cpp
@@ -76,6 +76,7 @@ StatusCode GeoSvc::buildDD4HepGeo() {
 }
 
 dd4hep::Detector* GeoSvc::getDetector() { return m_dd4hepgeo; }
+const dd4hep::Detector* GeoSvc::getDetector() const { return m_dd4hepgeo; }
 
 dd4hep::DetElement GeoSvc::getDD4HepGeo() { return m_dd4hepgeo->world(); }
 
@@ -93,6 +94,12 @@ StatusCode GeoSvc::buildGeant4Geo() {
 
 G4VUserDetectorConstruction* GeoSvc::getGeant4Geo() { return m_geant4geo.get(); }
 
-std::string GeoSvc::constantAsString(const std::string& name) { return m_dd4hepgeo->constantAsString(name); }
+std::string GeoSvc::constantAsString(std::string const& name) {
+  return m_dd4hepgeo->constantAsString(name);
+}
+std::string GeoSvc::constantAsString(std::string const& name) const {
+  return m_dd4hepgeo->constantAsString(name);
+}
+
 
 DECLARE_COMPONENT(GeoSvc)

--- a/Detector/DetComponents/src/GeoSvc.h
+++ b/Detector/DetComponents/src/GeoSvc.h
@@ -24,11 +24,13 @@ public:
   // This function generates the Geant4 geometry
   StatusCode buildGeant4Geo();
   // receive DD4hep Geometry
-  virtual dd4hep::DetElement getDD4HepGeo() override;
-  virtual dd4hep::Detector* getDetector() override;
-  virtual std::string constantAsString(std::string const& name) override;
+  virtual dd4hep::DetElement getDD4HepGeo();
+  virtual dd4hep::Detector* getDetector();
+  virtual const dd4hep::Detector* getDetector() const;
+  virtual std::string constantAsString(std::string const& name);
+  virtual std::string constantAsString(std::string const& name) const;
   // receive Geant4 Geometry
-  virtual G4VUserDetectorConstruction* getGeant4Geo() override;
+  virtual G4VUserDetectorConstruction* getGeant4Geo();
 
 private:
   // Pointer to the interface to the DD4hep geometry

--- a/SimG4Components/src/SimG4MagneticFieldTool.cpp
+++ b/SimG4Components/src/SimG4MagneticFieldTool.cpp
@@ -54,7 +54,7 @@ StatusCode SimG4MagneticFieldTool::initialize() {
   }
 
   info() << "Adding following field(s):" << endmsg;
-  dd4hep::Detector* detDescription = m_geoSvc->getDetector();
+  const dd4hep::Detector* detDescription = m_geoSvc->getDetector();
   auto fields = detDescription->fields();
   for (const auto& field : fields) {
     info() << "  - " << field.first << ": " << field.second->type << endmsg;


### PR DESCRIPTION
We want to make the methods of IGeoSvc const, for thread-safety and general cleanliness.
Here, we add change GeoSvc::getDetector and constantAsString to be const. However, for now (until the interface class is changed) we also retain the non-const overloads.

Also prepare for IGeoSvc::getDetector returning a const pointer.


BEGINRELEASENOTES
- Added const versions of the IGeoSvc interfaces to GeoSvc.
ENDRELEASENOTES
