### PR TITLE
Use the new utilities to set the CellID encoding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(ROOT COMPONENTS RIO Tree)
 # Load macros and functions for Gaudi-based projects
 find_package(Gaudi REQUIRED)
 find_package(k4FWCore 1.3 REQUIRED)
-find_package(EDM4HEP 0.99)
+find_package(EDM4HEP 1.0 REQUIRED)
 find_package(Geant4 REQUIRED)
 find_package(DD4hep REQUIRED)
 find_package(CLHEP REQUIRED)

--- a/Detector/DetComponents/src/RedoSegmentation.cpp
+++ b/Detector/DetComponents/src/RedoSegmentation.cpp
@@ -6,12 +6,6 @@
 // k4FWCore
 #include "k4FWCore/MetadataUtils.h"
 
-// podio
-#include "podio/Frame.h"
-
-// EDM4hep
-#include "edm4hep/Constants.h"
-
 DECLARE_COMPONENT(RedoSegmentation)
 
 RedoSegmentation::RedoSegmentation(const std::string& aName, ISvcLocator* aSvcLoc)
@@ -85,8 +79,7 @@ StatusCode RedoSegmentation::initialize() {
   else
     m_oldSegmentationType = 0;
 
-  auto cellIDEncodingName = podio::collMetadataParamName(m_outHits.objKey(), edm4hep::labels::CellIDEncoding);
-  k4FWCore::putParameter(cellIDEncodingName, m_segmentation->decoder()->fieldDescription());
+  k4FWCore::putCellIDEncoding(m_outHits.objKey(), m_segmentation->decoder()->fieldDescription(), this);
 
   return StatusCode::SUCCESS;
 }

--- a/Detector/DetComponents/src/RedoSegmentation.h
+++ b/Detector/DetComponents/src/RedoSegmentation.h
@@ -15,7 +15,6 @@
 
 // EDM4hep
 #include "edm4hep/CalorimeterHitCollection.h"
-#include "edm4hep/Constants.h"
 #include "edm4hep/SimCalorimeterHitCollection.h"
 
 /** @class RedoSegmentation Detector/DetComponents/src/RedoSegmentation.h RedoSegmentation.h

--- a/SimG4Components/src/SimG4SaveCalHits.cpp
+++ b/SimG4Components/src/SimG4SaveCalHits.cpp
@@ -14,12 +14,6 @@
 #include "DD4hep/Detector.h"
 #include "DD4hep/Segmentations.h"
 
-// podio
-#include "podio/Frame.h"
-
-// EDM4hep
-#include "edm4hep/Constants.h"
-
 DECLARE_COMPONENT(SimG4SaveCalHits)
 
 SimG4SaveCalHits::SimG4SaveCalHits(const std::string& aType, const std::string& aName, const IInterface* aParent)
@@ -85,8 +79,7 @@ StatusCode SimG4SaveCalHits::initialize() {
   // Add CellID encoding string to hit collection metadata
   auto idspec = lcdd->idSpecification(m_readoutName);
   auto field_str = idspec.fieldDescription();
-  auto cellIDEncodingName = podio::collMetadataParamName(m_caloHits.objKey(), edm4hep::labels::CellIDEncoding);
-  k4FWCore::putParameter(cellIDEncodingName, field_str);
+  k4FWCore::putCellIDEncoding(m_caloHits.objKey(), field_str, this);
   debug() << "Storing cell ID encoding string: \"" << field_str << "\"." << endmsg;
 
   return StatusCode::SUCCESS;

--- a/SimG4Components/src/SimG4SaveTrackerHits.cpp
+++ b/SimG4Components/src/SimG4SaveTrackerHits.cpp
@@ -85,8 +85,7 @@ StatusCode SimG4SaveTrackerHits::initialize() {
   // Add CellID encoding string to hit collection metadata
   auto idspec = lcdd->idSpecification(m_readoutName);
   auto field_str = idspec.fieldDescription();
-  auto cellIDEncodingName = podio::collMetadataParamName(m_trackHits.objKey(), edm4hep::labels::CellIDEncoding);
-  k4FWCore::putParameter(cellIDEncodingName, field_str);
+  k4FWCore::putCellIDEncoding(m_trackHits.objKey(), field_str, this);
   debug() << "Storing cell ID encoding string: \"" << field_str << "\"." << endmsg;
 
   return StatusCode::SUCCESS;


### PR DESCRIPTION

BEGINRELEASENOTES
- Use `k4FWCore::putCellIDEncoding` to store the cell id encoding strings

ENDRELEASENOTES

- [x] Needs https://github.com/key4hep/k4FWCore/pull/391