### PR TITLE
fix missing cellID encoding error

### DIFF
--- a/Detector/DetComponents/src/MergeLayers.cpp
+++ b/Detector/DetComponents/src/MergeLayers.cpp
@@ -12,9 +12,6 @@
 // DD4hep
 #include "DD4hep/Detector.h"
 
-// podio
-#include "podio/Frame.h"
-
 // ROOT
 #include "TGeoManager.h"
 

--- a/Detector/DetComponents/src/MergeLayers.cpp
+++ b/Detector/DetComponents/src/MergeLayers.cpp
@@ -8,7 +8,6 @@
 
 // EDM4hep
 #include "edm4hep/CalorimeterHitCollection.h"
-#include "edm4hep/Constants.h"
 
 // DD4hep
 #include "DD4hep/Detector.h"

--- a/Detector/DetComponents/src/MergeLayers.cpp
+++ b/Detector/DetComponents/src/MergeLayers.cpp
@@ -1,13 +1,20 @@
 #include "MergeLayers.h"
 
-// FCCSW
+// k4Interface
 #include "k4Interface/IGeoSvc.h"
 
-// datamodel
+// k4FWCore
+#include "k4FWCore/MetadataUtils.h"
+
+// EDM4hep
 #include "edm4hep/CalorimeterHitCollection.h"
+#include "edm4hep/Constants.h"
 
 // DD4hep
 #include "DD4hep/Detector.h"
+
+// podio
+#include "podio/Frame.h"
 
 // ROOT
 #include "TGeoManager.h"
@@ -55,6 +62,8 @@ StatusCode MergeLayers::initialize() {
             << endmsg;
     return StatusCode::FAILURE;
   }
+  auto cellIDEncodingName = podio::collMetadataParamName(m_outHits.objKey(), edm4hep::labels::CellIDEncoding);
+  k4FWCore::putParameter(cellIDEncodingName, m_descriptor.fieldDescription(), this);
   info() << "Field description: " << m_descriptor.fieldDescription() << endmsg;
   info() << "Merging volumes named: " << m_volumeName << endmsg;
   info() << "Merging volumes for identifier: " << m_idToMerge << endmsg;

--- a/Detector/DetComponents/src/MergeLayers.cpp
+++ b/Detector/DetComponents/src/MergeLayers.cpp
@@ -63,7 +63,7 @@ StatusCode MergeLayers::initialize() {
     return StatusCode::FAILURE;
   }
   auto cellIDEncodingName = podio::collMetadataParamName(m_outHits.objKey(), edm4hep::labels::CellIDEncoding);
-  k4FWCore::putParameter(cellIDEncodingName, m_descriptor.fieldDescription(), this);
+  k4FWCore::putCellIDEncoding(m_outHits.objKey(), m_descriptor.fieldDescription(), this);
   info() << "Field description: " << m_descriptor.fieldDescription() << endmsg;
   info() << "Merging volumes named: " << m_volumeName << endmsg;
   info() << "Merging volumes for identifier: " << m_idToMerge << endmsg;

--- a/Detector/DetComponents/src/MergeLayers.cpp
+++ b/Detector/DetComponents/src/MergeLayers.cpp
@@ -62,7 +62,6 @@ StatusCode MergeLayers::initialize() {
             << endmsg;
     return StatusCode::FAILURE;
   }
-  auto cellIDEncodingName = podio::collMetadataParamName(m_outHits.objKey(), edm4hep::labels::CellIDEncoding);
   k4FWCore::putCellIDEncoding(m_outHits.objKey(), m_descriptor.fieldDescription(), this);
   info() << "Field description: " << m_descriptor.fieldDescription() << endmsg;
   info() << "Merging volumes named: " << m_volumeName << endmsg;


### PR DESCRIPTION
When trying to revive the FCC-hh digitisation scripts, I encountered an error when using the MergeLayers algorithm, related to the fact that its output cells, later used by other algorithms, lack a Cell ID encoding. This MR fixes that error
BEGINRELEASENOTES
- declare cellID encoding of cells output by MergeLayers
ENDRELEASENOTES
